### PR TITLE
ci-cd(review): skip drafts and external authors, post review as PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' &&
+      github.event.pull_request.author_association != 'FIRST_TIMER' &&
+      github.event.pull_request.author_association != 'NONE'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,5 +38,47 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Post review as PR comment
+        if: always() && steps.claude-review.outputs.execution_file
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const executionFile = '${{ steps.claude-review.outputs.execution_file }}';
+            if (!fs.existsSync(executionFile)) {
+              console.log('No execution file found, skipping comment.');
+              return;
+            }
+            const review = fs.readFileSync(executionFile, 'utf8');
+            if (!review.trim()) {
+              console.log('Review output is empty, skipping comment.');
+              return;
+            }
+
+            // Find and update existing review comment, or create a new one
+            const marker = '<!-- claude-code-review -->';
+            const body = `${marker}\n## Claude Code Review\n\n${review}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- Skip Claude Code Review for draft PRs (triggers on `ready_for_review`)
- Skip for external/new contributors (`FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `NONE`)
- Post review output as a PR comment instead of only in workflow logs
- On re-runs (new pushes), updates the existing comment instead of creating duplicates

## Test plan
- [ ] Create a draft PR → verify review workflow does not trigger
- [ ] Mark draft as ready → verify review triggers
- [ ] Verify review comment appears on the PR after workflow completes
- [ ] Push again to same PR → verify comment is updated, not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)