### PR TITLE
feat(settings): lazy-load area options when settings panel opens

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -3,3 +3,4 @@ pnpm-lock.yaml
 .beads/
 **.md
 .claude/
+*.json

--- a/frontend/src/duck/reducer.ts
+++ b/frontend/src/duck/reducer.ts
@@ -19,7 +19,6 @@ export interface MapmemoState {
   areaOptions: AreaOption[]
   allSubAreaNames: string[]
   isAreaOptionsLoading: boolean
-  isAreaOptionsLoadFailed: boolean
   isAppInitialized: boolean
   cityInfo: CityInfo | null
 }
@@ -29,7 +28,6 @@ export const initialMapmemoState: MapmemoState = {
   areaOptions: [],
   allSubAreaNames: [],
   isAreaOptionsLoading: false,
-  isAreaOptionsLoadFailed: false,
   isAppInitialized: false,
   cityInfo: null,
 }
@@ -44,9 +42,6 @@ const mapmemoSlice = createSlice({
     loadAreaOptions() {},
     setAreaOptionsLoading(state, action: PayloadAction<boolean>) {
       state.isAreaOptionsLoading = action.payload
-    },
-    setAreaOptionsLoadFailed(state, action: PayloadAction<boolean>) {
-      state.isAreaOptionsLoadFailed = action.payload
     },
     setAreaOptions(state, action: PayloadAction<AreaOption[]>) {
       state.areaOptions = action.payload

--- a/frontend/src/duck/reducer.ts
+++ b/frontend/src/duck/reducer.ts
@@ -18,6 +18,7 @@ export interface MapmemoState {
   gameSettings: GameSettings
   areaOptions: AreaOption[]
   allSubAreaNames: string[]
+  isAreaOptionsLoading: boolean
   isAppInitialized: boolean
   cityInfo: CityInfo | null
 }
@@ -26,6 +27,7 @@ export const initialMapmemoState: MapmemoState = {
   gameSettings: DEFAULT_GAME_SETTINGS,
   areaOptions: [],
   allSubAreaNames: [],
+  isAreaOptionsLoading: false,
   isAppInitialized: false,
   cityInfo: null,
 }
@@ -36,6 +38,10 @@ const mapmemoSlice = createSlice({
   reducers: {
     setGameSettings(state, action: PayloadAction<GameSettings>) {
       state.gameSettings = action.payload
+    },
+    loadAreaOptions() {},
+    setAreaOptionsLoading(state, action: PayloadAction<boolean>) {
+      state.isAreaOptionsLoading = action.payload
     },
     setAreaOptions(state, action: PayloadAction<AreaOption[]>) {
       state.areaOptions = action.payload

--- a/frontend/src/duck/reducer.ts
+++ b/frontend/src/duck/reducer.ts
@@ -19,6 +19,7 @@ export interface MapmemoState {
   areaOptions: AreaOption[]
   allSubAreaNames: string[]
   isAreaOptionsLoading: boolean
+  isAreaOptionsLoadFailed: boolean
   isAppInitialized: boolean
   cityInfo: CityInfo | null
 }
@@ -28,6 +29,7 @@ export const initialMapmemoState: MapmemoState = {
   areaOptions: [],
   allSubAreaNames: [],
   isAreaOptionsLoading: false,
+  isAreaOptionsLoadFailed: false,
   isAppInitialized: false,
   cityInfo: null,
 }
@@ -42,6 +44,9 @@ const mapmemoSlice = createSlice({
     loadAreaOptions() {},
     setAreaOptionsLoading(state, action: PayloadAction<boolean>) {
       state.isAreaOptionsLoading = action.payload
+    },
+    setAreaOptionsLoadFailed(state, action: PayloadAction<boolean>) {
+      state.isAreaOptionsLoadFailed = action.payload
     },
     setAreaOptions(state, action: PayloadAction<AreaOption[]>) {
       state.areaOptions = action.payload

--- a/frontend/src/duck/sagas.ts
+++ b/frontend/src/duck/sagas.ts
@@ -37,7 +37,8 @@ function* handleLoadAreaOptions() {
     yield put(mapmemoActions.setAreaOptionsLoading(true))
     const response: Response = yield call(fetch, DELBYDELER_GEOJSON_URL)
     if (!response.ok) {
-      throw new Error('Failed to load Oslo GeoJSON, response: ' + response.text)
+      const text: string = yield call([response, response.text])
+      throw new Error('Failed to load Oslo GeoJSON, response: ' + text)
     }
     // SAFETY: Oslo-specific cast until multi-city GeoJSON support is added.
     const geojson = (yield call([response, response.json])) as OsloGeoJson
@@ -47,6 +48,7 @@ function* handleLoadAreaOptions() {
     yield put(mapmemoActions.setAllSubAreaNames(allSubAreaNames))
   } catch {
     // TODO: add silent error logging to sentry/similar
+    yield put(mapmemoActions.setAreaOptionsLoadFailed(true))
   } finally {
     yield put(mapmemoActions.setAreaOptionsLoading(false))
   }

--- a/frontend/src/duck/sagas.ts
+++ b/frontend/src/duck/sagas.ts
@@ -48,7 +48,6 @@ function* handleLoadAreaOptions() {
     yield put(mapmemoActions.setAllSubAreaNames(allSubAreaNames))
   } catch {
     // TODO: add silent error logging to sentry/similar
-    yield put(mapmemoActions.setAreaOptionsLoadFailed(true))
   } finally {
     yield put(mapmemoActions.setAreaOptionsLoading(false))
   }

--- a/frontend/src/duck/sagas.ts
+++ b/frontend/src/duck/sagas.ts
@@ -4,6 +4,12 @@ import type { GameSettings } from '../game/settings/settingsTypes'
 import type { CityInfo } from '../api/cityApi'
 import { fetchCityInfo } from '../api/cityApi'
 import { loadGameSettings, saveGameSettings } from './sagaUtils'
+import { DELBYDELER_GEOJSON_URL } from '../game/consts'
+import {
+  buildAllSubAreaNames,
+  buildAreaOptionsFromGeoJson,
+  type OsloGeoJson,
+} from '../game/utils'
 
 function* handleInitializeApp() {
   try {
@@ -26,6 +32,26 @@ function* handleInitializeApp() {
   }
 }
 
+function* handleLoadAreaOptions() {
+  try {
+    yield put(mapmemoActions.setAreaOptionsLoading(true))
+    const response: Response = yield call(fetch, DELBYDELER_GEOJSON_URL)
+    if (!response.ok) {
+      throw new Error('Failed to load Oslo GeoJSON, response: ' + response.text)
+    }
+    // SAFETY: Oslo-specific cast until multi-city GeoJSON support is added.
+    const geojson = (yield call([response, response.json])) as OsloGeoJson
+    const areaOptions = buildAreaOptionsFromGeoJson(geojson)
+    const allSubAreaNames = buildAllSubAreaNames(geojson)
+    yield put(mapmemoActions.setAreaOptions(areaOptions))
+    yield put(mapmemoActions.setAllSubAreaNames(allSubAreaNames))
+  } catch {
+    // TODO: add silent error logging to sentry/similar
+  } finally {
+    yield put(mapmemoActions.setAreaOptionsLoading(false))
+  }
+}
+
 function* handleGameSettingsChange(
   action: ReturnType<typeof mapmemoActions.setGameSettings>,
 ) {
@@ -40,5 +66,6 @@ export function* mapmemoSaga() {
   yield all([
     takeLatest(mapmemoActions.initializeApp.type, handleInitializeApp),
     takeLatest(mapmemoActions.setGameSettings.type, handleGameSettingsChange),
+    takeLatest(mapmemoActions.loadAreaOptions.type, handleLoadAreaOptions),
   ])
 }

--- a/frontend/src/game/hooks/useFeaturesInPlay.ts
+++ b/frontend/src/game/hooks/useFeaturesInPlay.ts
@@ -1,9 +1,17 @@
 import { useMapsLibrary } from '@vis.gl/react-google-maps'
 import { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { DELBYDELER_GEOJSON_URL } from '../consts'
 import type { AreaSubMode } from '../settings/settingsTypes'
-import { getAreaId } from '../utils'
+import {
+  getAreaId,
+  buildAreaOptionsFromGeoJson,
+  buildAllSubAreaNames,
+  type OsloGeoJson,
+} from '../utils'
 import { fetchWithSessionRetry } from '../../api/utils'
+import { mapmemoActions } from '../../duck/reducer'
+import type { AppDispatch, RootState } from '../../store'
 
 type GeoJsonObject = {
   type: string
@@ -84,6 +92,10 @@ type Props = {
 export const useFeaturesInPlay = ({ gameState }: Props) => {
   const mapsLibrary = useMapsLibrary('maps')
   const [allFeatures, setAllFeatures] = useState<google.maps.Data.Feature[]>([])
+  const dispatch = useDispatch<AppDispatch>()
+  const areaOptionsLoaded = useSelector(
+    (state: RootState) => state.mapmemo.areaOptions.length > 0,
+  )
 
   useEffect(
     function loadOsloGeoJson() {
@@ -104,7 +116,22 @@ export const useFeaturesInPlay = ({ gameState }: Props) => {
         if (!response.ok) {
           throw new Error('Failed to load Oslo GeoJSON')
         }
-        let geojson = (await response.json()) as GeoJsonObject
+        // SAFETY: Oslo-specific cast until multi-city GeoJSON support is added.
+        const rawGeojson = (await response.json()) as OsloGeoJson &
+          GeoJsonObject
+        if (!isActive) {
+          return
+        }
+
+        if (!areaOptionsLoaded) {
+          // settings uses area options.
+          const areaOptions = buildAreaOptionsFromGeoJson(rawGeojson)
+          const allSubAreaNames = buildAllSubAreaNames(rawGeojson)
+          dispatch(mapmemoActions.setAreaOptions(areaOptions))
+          dispatch(mapmemoActions.setAllSubAreaNames(allSubAreaNames))
+        }
+
+        let geojson: GeoJsonObject = rawGeojson
         if (getGeoJsonType(geojson) === 'EPSG:3857') {
           geojson = convertGeoJsonToLatLng(geojson)
         }

--- a/frontend/src/game/settings/AreaDropdown.tsx
+++ b/frontend/src/game/settings/AreaDropdown.tsx
@@ -62,33 +62,33 @@ export const AreaDropdown = ({
       </button>
       {isOpen && (
         <div className={s_dropdown_menu}>
-          {isLoading && (
+          {isLoading ? (
             <div className={s_dropdown_empty}>Loading areas...</div>
-          )}
-          {!isLoading && options.length === 0 && (
+          ) : options.length === 0 ? (
             <div className={s_dropdown_empty}>
               Failed to load areas. Try again later.
             </div>
+          ) : (
+            options.map((option) => {
+              const isChecked = selectedIds.includes(option.id)
+              return (
+                <label
+                  key={option.id}
+                  className={s_checkbox_option}
+                >
+                  <input
+                    type='checkbox'
+                    checked={isChecked}
+                    onChange={() => onToggleSelection(option.id)}
+                    className={s_checkbox}
+                  />
+                  <span>
+                    {option.name} ({option.count})
+                  </span>
+                </label>
+              )
+            })
           )}
-          {options.map((option) => {
-            const isChecked = selectedIds.includes(option.id)
-            return (
-              <label
-                key={option.id}
-                className={s_checkbox_option}
-              >
-                <input
-                  type='checkbox'
-                  checked={isChecked}
-                  onChange={() => onToggleSelection(option.id)}
-                  className={s_checkbox}
-                />
-                <span>
-                  {option.name} ({option.count})
-                </span>
-              </label>
-            )
-          })}
         </div>
       )}
     </div>

--- a/frontend/src/game/settings/AreaDropdown.tsx
+++ b/frontend/src/game/settings/AreaDropdown.tsx
@@ -66,7 +66,9 @@ export const AreaDropdown = ({
             <div className={s_dropdown_empty}>Loading areas...</div>
           )}
           {!isLoading && options.length === 0 && (
-            <div className={s_dropdown_empty}>No areas available</div>
+            <div className={s_dropdown_empty}>
+              Failed to load areas. Try again later.
+            </div>
           )}
           {options.map((option) => {
             const isChecked = selectedIds.includes(option.id)

--- a/frontend/src/game/settings/AreaDropdown.tsx
+++ b/frontend/src/game/settings/AreaDropdown.tsx
@@ -2,9 +2,10 @@ import { useEffect, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 import type { AreaOption } from './settingsTypes'
 
-type IProps = {
+type Props = {
   label: string
   options: AreaOption[]
+  isLoading: boolean
   selectedIds: string[]
   onToggleSelection: (areaId: string) => void
   outsideClickRef: RefObject<HTMLDivElement | null>
@@ -13,10 +14,11 @@ type IProps = {
 export const AreaDropdown = ({
   label,
   options,
+  isLoading,
   selectedIds,
   onToggleSelection,
   outsideClickRef,
-}: IProps) => {
+}: Props) => {
   const dropdownRoot = useRef<HTMLDivElement | null>(null)
   const [isOpen, setIsOpen] = useState(false)
 
@@ -60,8 +62,11 @@ export const AreaDropdown = ({
       </button>
       {isOpen && (
         <div className={s_dropdown_menu}>
-          {options.length === 0 && (
+          {isLoading && (
             <div className={s_dropdown_empty}>Loading areas...</div>
+          )}
+          {!isLoading && options.length === 0 && (
+            <div className={s_dropdown_empty}>No areas available</div>
           )}
           {options.map((option) => {
             const isChecked = selectedIds.includes(option.id)

--- a/frontend/src/game/settings/GameSettings.tsx
+++ b/frontend/src/game/settings/GameSettings.tsx
@@ -50,6 +50,9 @@ export const GameSettings = ({
   const isAreaOptionsLoading = useSelector(
     (state: RootState) => state.mapmemo.isAreaOptionsLoading,
   )
+  const isAreaOptionsLoadFailed = useSelector(
+    (state: RootState) => state.mapmemo.isAreaOptionsLoadFailed,
+  )
   const reduxCityInfo = useSelector(
     (state: RootState) => state.mapmemo.cityInfo,
   )
@@ -62,6 +65,27 @@ export const GameSettings = ({
     'warning' | 'error'
   >('warning')
 
+  useEffect(
+    function loadAreaOptionsWhenNeeded() {
+      const showAreaSettings = draftSettings.mode !== 'route'
+      if (
+        showAreaSettings &&
+        areaOptions.length === 0 &&
+        !isAreaOptionsLoading &&
+        !isAreaOptionsLoadFailed
+      ) {
+        dispatch(mapmemoActions.loadAreaOptions())
+      }
+    },
+    [
+      draftSettings.mode,
+      areaOptions.length,
+      isAreaOptionsLoading,
+      isAreaOptionsLoadFailed,
+      dispatch,
+    ],
+  )
+
   const handleAddressError = (
     error: string | null,
     level: 'warning' | 'error',
@@ -73,19 +97,6 @@ export const GameSettings = ({
   const isNameMode = draftSettings.mode === 'name'
   const showDifficulty = isNameMode
   const showAreaSettings = !isRouteMode
-
-  useEffect(
-    function loadAreaOptionsWhenNeeded() {
-      if (
-        showAreaSettings &&
-        areaOptions.length === 0 &&
-        !isAreaOptionsLoading
-      ) {
-        dispatch(mapmemoActions.loadAreaOptions())
-      }
-    },
-    [showAreaSettings, areaOptions.length, isAreaOptionsLoading, dispatch],
-  )
   const selectedAreaCount = draftSettings.selectedAreas.length
   const areaButtonLabel =
     selectedAreaCount === 0 ? 'All areas' : `${selectedAreaCount} selected`

--- a/frontend/src/game/settings/GameSettings.tsx
+++ b/frontend/src/game/settings/GameSettings.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import type { AppDispatch, RootState } from '../../store'
 import { mapmemoActions } from '../../duck/reducer'
@@ -47,6 +47,9 @@ export const GameSettings = ({
   const areaOptions = useSelector(
     (state: RootState) => state.mapmemo.areaOptions,
   )
+  const isAreaOptionsLoading = useSelector(
+    (state: RootState) => state.mapmemo.isAreaOptionsLoading,
+  )
   const reduxCityInfo = useSelector(
     (state: RootState) => state.mapmemo.cityInfo,
   )
@@ -70,6 +73,19 @@ export const GameSettings = ({
   const isNameMode = draftSettings.mode === 'name'
   const showDifficulty = isNameMode
   const showAreaSettings = !isRouteMode
+
+  useEffect(
+    function loadAreaOptionsWhenNeeded() {
+      if (
+        showAreaSettings &&
+        areaOptions.length === 0 &&
+        !isAreaOptionsLoading
+      ) {
+        dispatch(mapmemoActions.loadAreaOptions())
+      }
+    },
+    [showAreaSettings, areaOptions.length, isAreaOptionsLoading, dispatch],
+  )
   const selectedAreaCount = draftSettings.selectedAreas.length
   const areaButtonLabel =
     selectedAreaCount === 0 ? 'All areas' : `${selectedAreaCount} selected`
@@ -342,6 +358,7 @@ export const GameSettings = ({
           <AreaDropdown
             label={areaButtonLabel}
             options={areaOptions}
+            isLoading={isAreaOptionsLoading}
             selectedIds={draftSettings.selectedAreas}
             onToggleSelection={toggleAreaSelection}
             outsideClickRef={containerRef}

--- a/frontend/src/game/settings/GameSettings.tsx
+++ b/frontend/src/game/settings/GameSettings.tsx
@@ -50,9 +50,6 @@ export const GameSettings = ({
   const isAreaOptionsLoading = useSelector(
     (state: RootState) => state.mapmemo.isAreaOptionsLoading,
   )
-  const isAreaOptionsLoadFailed = useSelector(
-    (state: RootState) => state.mapmemo.isAreaOptionsLoadFailed,
-  )
   const reduxCityInfo = useSelector(
     (state: RootState) => state.mapmemo.cityInfo,
   )
@@ -65,26 +62,15 @@ export const GameSettings = ({
     'warning' | 'error'
   >('warning')
 
-  useEffect(
-    function loadAreaOptionsWhenNeeded() {
-      const showAreaSettings = draftSettings.mode !== 'route'
-      if (
-        showAreaSettings &&
-        areaOptions.length === 0 &&
-        !isAreaOptionsLoading &&
-        !isAreaOptionsLoadFailed
-      ) {
-        dispatch(mapmemoActions.loadAreaOptions())
-      }
-    },
-    [
-      draftSettings.mode,
-      areaOptions.length,
-      isAreaOptionsLoading,
-      isAreaOptionsLoadFailed,
-      dispatch,
-    ],
-  )
+  useEffect(function loadAreaOptionsOnMount() {
+    if (
+      draftSettings.mode !== 'route' &&
+      areaOptions.length === 0 &&
+      !isAreaOptionsLoading
+    ) {
+      dispatch(mapmemoActions.loadAreaOptions())
+    }
+  }, [])
 
   const handleAddressError = (
     error: string | null,
@@ -115,6 +101,13 @@ export const GameSettings = ({
           lng: a.lng,
         }))
       : []
+
+  const handleModeChange = (mode: GameSettingsModel['mode']) => {
+    setDraftSettings((prev) => ({ ...prev, mode }))
+    if (mode !== 'route' && areaOptions.length === 0 && !isAreaOptionsLoading) {
+      dispatch(mapmemoActions.loadAreaOptions())
+    }
+  }
 
   const handleSeedChange = (value: string) => {
     const filtered = value.replace(/[^a-z0-9]/gi, '').toLowerCase()
@@ -222,12 +215,7 @@ export const GameSettings = ({
                 key={option.value}
                 type='button'
                 title={MODE_DESCRIPTIONS[option.value]}
-                onClick={() =>
-                  setDraftSettings((prev) => ({
-                    ...prev,
-                    mode: option.value,
-                  }))
-                }
+                onClick={() => handleModeChange(option.value)}
                 className={sf_option_button(isSelected, false)}
               >
                 {option.label}

--- a/frontend/src/game/settings/GameSettings.tsx
+++ b/frontend/src/game/settings/GameSettings.tsx
@@ -70,6 +70,7 @@ export const GameSettings = ({
     ) {
       dispatch(mapmemoActions.loadAreaOptions())
     }
+    // Should only run on mount. Revisit when react compiler releases exhaustive-deps rule for use with compiler.
   }, [])
 
   const handleAddressError = (


### PR DESCRIPTION
## Summary

- Removes the app-init GeoJSON fetch that was broken in 60a567f
- Adds a `loadAreaOptions` saga action triggered lazily from `GameSettings` when area mode is shown and options are empty
- `takeLatest` prevents duplicate in-flight fetches
- Adds `isAreaOptionsLoading` to Redux state; `AreaDropdown` now receives an explicit `isLoading` prop to distinguish loading vs. truly empty states

## Test plan

- [x] Open settings in click/name mode → area options load and appear in dropdown
- [ ] Switch to route mode and back → options already cached, no refetch
- [ ] Open settings directly in route mode → no fetch triggered
- [ ] Simulate slow network: dropdown should show "Loading areas..." while fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)