### PR TITLE
feat(info): game info panel with mode-specific content and collapsible sections

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:browser": "vite --open",
     "build": "tsc -b && vite build",
+    "build:vercel": "git fetch --tags --depth=1 && pnpm build",
     "lint": "eslint . --max-warnings 0",
     "lint-fix": "eslint . --fix",
     "format": "prettier . --write",

--- a/frontend/src/components/AppFooter.tsx
+++ b/frontend/src/components/AppFooter.tsx
@@ -1,19 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useSettingsOpen } from '../game/settings/SettingsOpenContext'
 
-const REPO = 'https://github.com/haraldgb/mapmemo'
-
-const getVersionInfo = (version: string): { display: string; url: string } => {
-  if (/^[0-9a-f]+$/i.test(version)) {
-    return { display: `#${version}`, url: `${REPO}/commit/${version}` }
-  }
-  const offsetMatch = version.match(/^(.+)-\d+-g([0-9a-f]+)$/)
-  if (offsetMatch) {
-    return { display: version, url: `${REPO}/commit/${offsetMatch[2]}` }
-  }
-  return { display: version, url: `${REPO}/releases/tag/${version}` }
-}
-
 interface AppFooterProps {
   version: string
   isGameRoute: boolean
@@ -22,19 +9,11 @@ interface AppFooterProps {
 export const AppFooter = ({ version, isGameRoute }: AppFooterProps) => {
   const { isSettingsOpen, isInfoOpen } = useSettingsOpen()
   const isVisible = !isGameRoute || isSettingsOpen || isInfoOpen
-  const { display, url } = getVersionInfo(version)
 
   return (
     <footer className={sf_footer(isGameRoute, isVisible)}>
       <div className={s_footer_inner}>
-        <a
-          href={url}
-          className={s_repo_link}
-          rel='noreferrer'
-          target='_blank'
-        >
-          Version {display}
-        </a>
+        <span className={s_version}>{version}</span>
         <div className={s_footer_links}>
           <Link
             to='/privacy'
@@ -77,8 +56,8 @@ const sf_footer = (isGameRoute: boolean, isVisible: boolean) => {
   return `${gameBase} ${gamePosition} ${visibility}`
 }
 const s_footer_inner =
-  'flex flex-row w-full gap-1 px-4 py-1.5 text-xs sm:items-center justify-between  text-slate-500'
-
+  'flex flex-row w-full gap-1 px-4 py-1.5 text-xs text-slate-500 sm:items-center justify-between'
+const s_version = 'text-slate-500 cursor-default'
 const s_footer_links = 'flex items-center gap-4'
 const s_repo_link =
   'inline-flex items-center gap-1.5 text-slate-500 transition hover:text-slate-900'

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -60,7 +60,10 @@ export const GameInfoSection = ({
   useEffect(
     function scrollIntoViewOnOpen() {
       if (isOpen) {
-        contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        contentRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        })
       }
     },
     [isOpen],
@@ -102,7 +105,7 @@ export const GameInfoList = ({ children }: ChildProps) => {
 }
 
 export const GameInfoListItem = ({ children }: ChildProps) => {
-  return <li>{children}</li>
+  return <li className={s_list_item}>{children}</li>
 }
 
 export const GameInfoDivider = () => {
@@ -134,7 +137,8 @@ const s_section_button =
 const sf_chevron = (isOpen: boolean) =>
   `h-3.5 w-3.5 text-slate-400 transition-transform duration-150${isOpen ? '' : ' -rotate-90'}`
 const s_paragraph = 'mt-2 text-sm leading-relaxed text-slate-600'
-const s_list = 'mt-2 space-y-1.5 text-sm leading-relaxed text-slate-600'
+const s_list = 'mt-2 space-y-2 text-sm leading-relaxed text-slate-600'
+const s_list_item = 'border-l-2 border-slate-200 pl-3 py-0.5'
 const s_divider = 'my-3 border-t border-slate-100'
 const s_footer_divider = 'mb-3 border-t border-slate-100'
 const s_link =

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -1,0 +1,134 @@
+import { useState, type ReactNode } from 'react'
+import { ChevronIcon } from './icons/ChevronIcon'
+
+type Props = {
+  title: string
+  children: ReactNode
+  onClose: () => void
+}
+
+export const GameInfo = ({ title, children, onClose }: Props) => {
+  return (
+    <div className={s_panel}>
+      <div className={s_header}>
+        <div className={s_title}>{title}</div>
+      </div>
+      <div className={s_content}>{children}</div>
+      <div className={s_footer}>
+        <div className={s_footer_divider} />
+        <p className={s_paragraph}>
+          Notice something wrong?{' '}
+          <a
+            href='https://github.com/haraldgb/mapmemo/issues/new'
+            target='_blank'
+            rel='noopener noreferrer'
+            className={s_link}
+          >
+            Report an issue
+          </a>
+        </p>
+        <div className={s_actions}>
+          <button
+            type='button'
+            onClick={onClose}
+            className={s_close_button}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type ChildProps = { children: ReactNode }
+
+type SectionProps = {
+  title: string
+  children: ReactNode
+  defaultOpen: boolean
+}
+
+export const GameInfoSection = ({
+  title,
+  children,
+  defaultOpen,
+}: SectionProps) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen)
+  }
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={handleToggle}
+        className={s_section_button}
+      >
+        <span className={s_subtitle}>{title}</span>
+        <ChevronIcon className={sf_chevron(isOpen)} />
+      </button>
+      {isOpen && <div>{children}</div>}
+    </div>
+  )
+}
+
+export const GameInfoTitle = ({ children }: ChildProps) => {
+  return <div className={s_title}>{children}</div>
+}
+
+export const GameInfoSubtitle = ({ children }: ChildProps) => {
+  return <div className={s_subtitle}>{children}</div>
+}
+
+export const GameInfoParagraph = ({ children }: ChildProps) => {
+  return <p className={s_paragraph}>{children}</p>
+}
+
+export const GameInfoList = ({ children }: ChildProps) => {
+  return <ul className={s_list}>{children}</ul>
+}
+
+export const GameInfoListItem = ({ children }: ChildProps) => {
+  return <li>{children}</li>
+}
+
+export const GameInfoDivider = () => {
+  return <div className={s_divider} />
+}
+
+export const Bold = ({ children }: ChildProps) => {
+  return <span className='font-semibold text-slate-700'>{children}</span>
+}
+
+export const Italic = ({ children }: ChildProps) => {
+  return <span className='italic'>{children}</span>
+}
+
+export const Underline = ({ children }: ChildProps) => {
+  return <span className='underline underline-offset-2'>{children}</span>
+}
+
+const s_panel =
+  'flex h-[635px] max-h-[calc(100dvh-6rem)] w-[343px] flex-col rounded-xl border border-slate-200 bg-white text-left shadow-lg'
+const s_header = 'shrink-0 border-b border-slate-200 px-4 py-3 shadow-sm'
+const s_content = 'flex-1 overflow-auto px-4'
+const s_footer = 'shrink-0 px-4 pb-4'
+const s_title = 'text-base font-semibold text-slate-900'
+const s_subtitle =
+  'mt-3 text-xs font-semibold uppercase tracking-wide text-slate-500'
+const s_section_button =
+  'mt-3 flex w-full items-center justify-between hover:opacity-70'
+const sf_chevron = (isOpen: boolean) =>
+  `h-3.5 w-3.5 text-slate-400 transition-transform duration-150${isOpen ? '' : ' -rotate-90'}`
+const s_paragraph = 'mt-2 text-sm leading-relaxed text-slate-600'
+const s_list = 'mt-2 space-y-1.5 text-sm leading-relaxed text-slate-600'
+const s_divider = 'my-3 border-t border-slate-100'
+const s_footer_divider = 'mb-3 border-t border-slate-100'
+const s_link =
+  'font-semibold text-purple-600 underline underline-offset-2 hover:text-purple-700'
+const s_actions = 'mt-4 flex justify-end'
+const s_close_button =
+  'rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:bg-slate-50'

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -57,9 +57,15 @@ export const GameInfoSection = ({
   const [isOpen, setIsOpen] = useState(defaultOpen)
   const contentRef = useRef<HTMLDivElement>(null)
 
+  // escapes scrollIntoViewOnOpen for first render
+  const [prevIsOpen, setIsPrevOpen] = useState(isOpen)
+  if (prevIsOpen !== isOpen) {
+    setIsPrevOpen(isOpen)
+  }
+
   useEffect(
     function scrollIntoViewOnOpen() {
-      if (isOpen) {
+      if (isOpen && prevIsOpen !== isOpen) {
         contentRef.current?.scrollIntoView({
           behavior: 'smooth',
           block: 'nearest',

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react'
+import { useState, useEffect, useRef, type ReactNode } from 'react'
 import { ChevronIcon } from './icons/ChevronIcon'
 
 type Props = {
@@ -55,6 +55,16 @@ export const GameInfoSection = ({
   defaultOpen,
 }: SectionProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(
+    function scrollIntoViewOnOpen() {
+      if (isOpen) {
+        contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    },
+    [isOpen],
+  )
 
   const handleToggle = () => {
     setIsOpen(!isOpen)
@@ -70,7 +80,7 @@ export const GameInfoSection = ({
         <span className={s_subtitle}>{title}</span>
         <ChevronIcon className={sf_chevron(isOpen)} />
       </button>
-      {isOpen && <div>{children}</div>}
+      {isOpen && <div ref={contentRef}>{children}</div>}
     </div>
   )
 }
@@ -112,7 +122,7 @@ export const Underline = ({ children }: ChildProps) => {
 }
 
 const s_panel =
-  'flex h-[635px] max-h-[calc(100dvh-6rem)] w-[343px] flex-col rounded-xl border border-slate-200 bg-white text-left shadow-lg'
+  'flex h-[635px] max-h-[calc(100dvh-6rem)] w-[343px] sm:w-[514px] md:w-[686px] flex-col rounded-xl border border-slate-200 bg-white text-left shadow-lg'
 const s_header = 'shrink-0 border-b border-slate-200 px-4 py-3 shadow-sm'
 const s_content = 'flex-1 overflow-auto px-4 pt-2'
 const s_footer = 'shrink-0 px-4 pb-4'

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -100,21 +100,21 @@ export const GameInfoDivider = () => {
 }
 
 export const Bold = ({ children }: ChildProps) => {
-  return <span className='font-semibold text-slate-700'>{children}</span>
+  return <span className={s_bold}>{children}</span>
 }
 
 export const Italic = ({ children }: ChildProps) => {
-  return <span className='italic'>{children}</span>
+  return <span className={s_italic}>{children}</span>
 }
 
 export const Underline = ({ children }: ChildProps) => {
-  return <span className='underline underline-offset-2'>{children}</span>
+  return <span className={s_underline}>{children}</span>
 }
 
 const s_panel =
   'flex h-[635px] max-h-[calc(100dvh-6rem)] w-[343px] flex-col rounded-xl border border-slate-200 bg-white text-left shadow-lg'
 const s_header = 'shrink-0 border-b border-slate-200 px-4 py-3 shadow-sm'
-const s_content = 'flex-1 overflow-auto px-4'
+const s_content = 'flex-1 overflow-auto px-4 pt-2'
 const s_footer = 'shrink-0 px-4 pb-4'
 const s_title = 'text-base font-semibold text-slate-900'
 const s_subtitle =
@@ -132,3 +132,6 @@ const s_link =
 const s_actions = 'mt-4 flex justify-end'
 const s_close_button =
   'rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:bg-slate-50'
+const s_bold = 'font-semibold text-slate-700'
+const s_italic = 'italic'
+const s_underline = 'underline underline-offset-2'

--- a/frontend/src/game/GameInfoButton.tsx
+++ b/frontend/src/game/GameInfoButton.tsx
@@ -1,4 +1,9 @@
+import { type MouseEvent } from 'react'
+import { useSelector } from 'react-redux'
 import { InfoIcon } from '../components/icons/InfoIcon'
+import type { RootState } from '../store'
+import { AreaGameInfo } from './area/AreaGameInfo'
+import { RouteGameInfo } from './route/RouteGameInfo'
 import { useSettingsOpen } from './settings/SettingsOpenContext'
 
 type Props = {
@@ -7,10 +12,13 @@ type Props = {
 
 export const GameInfoButton = ({ isDisabled = false }: Props) => {
   const { isInfoOpen, setIsInfoOpen } = useSettingsOpen()
+  const mode = useSelector(
+    (state: RootState) => state.mapmemo.gameSettings.mode,
+  )
 
   const disabled = isDisabled
 
-  const handleBackdropClick = (event: React.MouseEvent) => {
+  const handleBackdropClick = (event: MouseEvent) => {
     if (event.target === event.currentTarget) {
       setIsInfoOpen(false)
     }
@@ -32,49 +40,11 @@ export const GameInfoButton = ({ isDisabled = false }: Props) => {
           className={s_overlay}
           onMouseDown={handleBackdropClick}
         >
-          <div className={s_panel}>
-            <div className={s_title}>About MapMemo</div>
-            <p className={s_paragraph}>
-              MapMemo is a geography memorization game where you learn city
-              neighborhoods and road layouts by clicking on a map.
-            </p>
-            <div className={s_subtitle}>Data sources</div>
-            <ul className={s_list}>
-              <li>
-                <span className={s_source}>Google Maps</span> — base map tiles
-                and rendering
-              </li>
-              <li>
-                <span className={s_source}>OpenStreetMap</span> — road network
-                data for route calculations
-              </li>
-              <li>
-                <span className={s_source}>Oslo Kommune GeoJSON</span> — area
-                and neighborhood boundaries
-              </li>
-            </ul>
-            <div className={s_divider} />
-            <p className={s_paragraph}>
-              Notice something wrong?{' '}
-              <a
-                href='https://github.com/haraldgb/mapmemo/issues/new'
-                target='_blank'
-                rel='noopener noreferrer'
-                className={s_link}
-              >
-                Report an issue
-              </a>
-            </p>
-            <div className={s_actions}>
-              <button
-                type='button'
-                onClick={() => setIsInfoOpen(false)}
-                className={s_close_button}
-              >
-                Close
-              </button>
-            </div>
-          </div>
+          {mode === 'route' ? (
+            <RouteGameInfo onClose={() => setIsInfoOpen(false)} />
+          ) : (
+            <AreaGameInfo onClose={() => setIsInfoOpen(false)} />
+          )}
         </div>
       )}
     </>
@@ -86,17 +56,3 @@ const sf_info_button = (disabled: boolean) =>
 const s_info_icon = 'h-5 w-5'
 const s_overlay =
   'pointer-events-auto fixed inset-0 z-20 flex items-center justify-center'
-const s_panel =
-  'w-[343px] rounded-xl border border-slate-200 bg-white p-4 text-left shadow-lg'
-const s_title = 'text-sm font-semibold text-slate-900'
-const s_subtitle =
-  'mt-3 text-xs font-semibold uppercase tracking-wide text-slate-500'
-const s_paragraph = 'mt-2 text-sm leading-relaxed text-slate-600'
-const s_list = 'mt-2 space-y-1.5 text-sm leading-relaxed text-slate-600'
-const s_source = 'font-semibold text-slate-700'
-const s_divider = 'my-3 border-t border-slate-100'
-const s_link =
-  'font-semibold text-purple-600 underline underline-offset-2 hover:text-purple-700'
-const s_actions = 'mt-4 flex justify-end'
-const s_close_button =
-  'rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:bg-slate-50'

--- a/frontend/src/game/area/AreaGameInfo.tsx
+++ b/frontend/src/game/area/AreaGameInfo.tsx
@@ -1,0 +1,93 @@
+import { useSelector } from 'react-redux'
+import {
+  GameInfo,
+  GameInfoList,
+  GameInfoListItem,
+  GameInfoParagraph,
+  GameInfoSection,
+} from '../../components/GameInfo'
+import type { RootState } from '../../store'
+
+type Props = {
+  onClose: () => void
+}
+
+export const AreaGameInfo = ({ onClose }: Props) => {
+  const mode = useSelector(
+    (state: RootState) => state.mapmemo.gameSettings.mode,
+  )
+  return (
+    <GameInfo
+      title={mode === 'click' ? 'Click mode' : 'Name mode'}
+      onClose={onClose}
+    >
+      <GameInfoParagraph>
+        {mode === 'click'
+          ? 'Click on the map to identify neighborhoods and districts in the city.'
+          : 'Input the name of the neighborhoods and districts of the city'}
+      </GameInfoParagraph>
+      <GameInfoSection
+        title='How to play'
+        defaultOpen
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            {mode === 'click'
+              ? 'Click somewhere on the map to guess where the prompted area is.'
+              : "Write the name of the blinking area. Use the input's auto-complete function to help you(auto-complete not available for harder difficulties)."}
+          </GameInfoListItem>
+          <GameInfoListItem>
+            {mode === 'click'
+              ? 'Correct guesses will paint the area green and take you to the next area'
+              : 'Correct guesses will paint the area green and take you to the next area'}
+            Correct guesses light up the area in green.
+          </GameInfoListItem>
+          {mode === 'click' ? (
+            <GameInfoListItem>
+              Incorrect guesses will tell you the area you actually guessed, and
+              blink the correct one in red'
+            </GameInfoListItem>
+          ) : null}
+        </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Data'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            {mode === 'click' ? 'Click' : 'Name'} mode uses data from Oslo
+            Kommune together with Google Maps' map. This is why Oslo, Norway is
+            the only city available for this mode.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            Open Street Map have some area data, but their granularity differs
+            from country to country(city/neigborhood/electoral districts). More
+            cities TBD.
+          </GameInfoListItem>
+        </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Known limitations'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            Setting a new seed only randomizes the order if using "AREAS - Full
+            Pool", not what areas are included. TBD.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            In order to not make the game too easy, the mode uses a map version
+            where a lot of features(roads, labels, landmarks, etc.) are hidden.
+            This difference might make the map less recognizable.
+          </GameInfoListItem>
+          {mode === 'name' ? (
+            <GameInfoListItem>
+              Name mode is quite janky to play on a mobile device. TBD.
+            </GameInfoListItem>
+          ) : null}
+        </GameInfoList>
+      </GameInfoSection>
+    </GameInfo>
+  )
+}

--- a/frontend/src/game/area/AreaGameInfo.tsx
+++ b/frontend/src/game/area/AreaGameInfo.tsx
@@ -34,18 +34,16 @@ export const AreaGameInfo = ({ onClose }: Props) => {
           <GameInfoListItem>
             {mode === 'click'
               ? 'Click somewhere on the map to guess where the prompted area is.'
-              : "Write the name of the blinking area. Use the input's auto-complete function to help you(auto-complete not available for harder difficulties)."}
+              : "Write the name of the blinking area. Use the input's auto-complete function to help you."}
           </GameInfoListItem>
           <GameInfoListItem>
-            {mode === 'click'
-              ? 'Correct guesses will paint the area green and take you to the next area'
-              : 'Correct guesses will paint the area green and take you to the next area'}
-            Correct guesses light up the area in green.
+            Correct guesses will paint the area green and take you to the next
+            area
           </GameInfoListItem>
           {mode === 'click' ? (
             <GameInfoListItem>
               Incorrect guesses will tell you the area you actually guessed, and
-              blink the correct one in red'
+              blink the correct one in red
             </GameInfoListItem>
           ) : null}
         </GameInfoList>
@@ -84,6 +82,34 @@ export const AreaGameInfo = ({ onClose }: Props) => {
           {mode === 'name' ? (
             <GameInfoListItem>
               Name mode is quite janky to play on a mobile device. TBD.
+            </GameInfoListItem>
+          ) : null}
+        </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Features to come'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            Versus mode - play realtime against other players
+          </GameInfoListItem>
+          <GameInfoListItem>
+            3 attempts that score differently. Correct answer revealed at 3rd
+            incorrect attempt
+          </GameInfoListItem>
+          {mode === 'click' ? (
+            <GameInfoListItem>Difficulty levels</GameInfoListItem>
+          ) : null}
+          {mode === 'name' ? (
+            <GameInfoListItem>
+              Name is revealed letter by letter with incorrect answers
+            </GameInfoListItem>
+          ) : null}
+          {mode === 'name' ? (
+            <GameInfoListItem>
+              Name match indicator for difficulty hard - suggests similar
+              spellings or confirms possible match.
             </GameInfoListItem>
           ) : null}
         </GameInfoList>

--- a/frontend/src/game/route/RouteGameInfo.tsx
+++ b/frontend/src/game/route/RouteGameInfo.tsx
@@ -1,0 +1,93 @@
+import {
+  Bold,
+  GameInfo,
+  GameInfoList,
+  GameInfoListItem,
+  GameInfoParagraph,
+  GameInfoSection,
+} from '../../components/GameInfo'
+
+type Props = {
+  onClose: () => void
+}
+
+export const RouteGameInfo = ({ onClose }: Props) => {
+  return (
+    <GameInfo
+      title='Route Game'
+      onClose={onClose}
+    >
+      <GameInfoParagraph>
+        Navigate from <Bold>A to B</Bold> through the cities' junctions and
+        roads.
+      </GameInfoParagraph>
+      <GameInfoSection
+        title='How to play'
+        defaultOpen
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            Your goal is to find the quickest route possible between two
+            addresses. Click an available junction(purple dot) to select it.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            That junction connects you to new road(s). A new set of junctions
+            should be available.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            Keep adding junctions to your route until you are connected to the
+            road of your end goal(road name must match address).
+          </GameInfoListItem>
+          <GameInfoListItem>
+            Click <Bold>B</Bold> to complete the route and end the game.
+          </GameInfoListItem>
+        </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Data'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            Route mode uses a mix of data from Google Maps and Open Street Maps.
+            OSM data is used to bridge the gaps between Google Maps' available
+            and unavailable data - e.g. their junction data is not readily
+            available.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            OSM data is crowd sourced, which has its limitations. It is for
+            instance often diverging a bit from Google Maps' data. If junctions
+            seem mis-positioned, or some addresses don't work, this is likely
+            the cause.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            Maps' data is live from their APIs - OSM data is snapshotted in
+            time. Contributing and fixing OSM data will not update the game
+            straight away, but let me know and I can make a new snapshot.
+          </GameInfoListItem>
+        </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Known limitations'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>
+            Selectable junctions are only partly decided by traffic rules. This
+            might lead you to pick an "illegal" junction, which Google Maps'
+            route calculation still has to pass through, taking a detour. As
+            long as you know your way around, this shouldn't be a problem! ;-)
+          </GameInfoListItem>
+          <GameInfoListItem>
+            The game uses the end address' road name to determine if it can be
+            reached from current position. The address does not always
+            correspond with the actual entrance/exit. This might make getting to
+            the end point a bit awkward. As Google Maps has additional
+            entrance/exit info this also makes the calculated routes a bit
+            different.
+          </GameInfoListItem>
+        </GameInfoList>
+      </GameInfoSection>
+    </GameInfo>
+  )
+}

--- a/frontend/src/game/route/RouteGameInfo.tsx
+++ b/frontend/src/game/route/RouteGameInfo.tsx
@@ -28,7 +28,7 @@ export const RouteGameInfo = ({ onClose }: Props) => {
         <GameInfoList>
           <GameInfoListItem>
             Your goal is to find the quickest route possible between two
-            addresses. Click an available junction(purple dot) to select it.
+            addresses. Click a available junction(purple dot) to select it.
           </GameInfoListItem>
           <GameInfoListItem>
             That junction connects you to new road(s). A new set of junctions
@@ -73,7 +73,13 @@ export const RouteGameInfo = ({ onClose }: Props) => {
       >
         <GameInfoList>
           <GameInfoListItem>
-            Selectable junctions are only partly decided by traffic rules. This
+            Did your driving instructor ever tell you that no instruction means
+            continue forward? Here, this is the case for continuing along the
+            same road. Only junctions reachable through the included roads of
+            your current junction are available.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            Available junctions are only partly decided by traffic rules. This
             might lead you to pick an "illegal" junction, which Google Maps'
             route calculation still has to pass through, taking a detour. As
             long as you know your way around, this shouldn't be a problem! ;-)
@@ -91,6 +97,11 @@ export const RouteGameInfo = ({ onClose }: Props) => {
             bound. These are not calculated correctly for all cities. This
             causes some addresses to not be searchable. TBD.
           </GameInfoListItem>
+          <GameInfoListItem>
+            Some roads in the same city share name. All these roads' junctions
+            are available if your current junction's address share their road
+            name. TBD.
+          </GameInfoListItem>
         </GameInfoList>
       </GameInfoSection>
       <GameInfoSection
@@ -99,13 +110,13 @@ export const RouteGameInfo = ({ onClose }: Props) => {
       >
         <GameInfoList>
           <GameInfoListItem>Versus mode</GameInfoListItem>
+          <GameInfoListItem>
+            Play multiple routes in a row, accumulate score / route diff
+          </GameInfoListItem>
+          <GameInfoListItem>Traffic settings</GameInfoListItem>
+          <GameInfoListItem>Pedestrian routes</GameInfoListItem>
+          <GameInfoListItem>Public transport routes</GameInfoListItem>
         </GameInfoList>
-        <GameInfoListItem>
-          Play multiple routes in a row, accumulate score / route diff
-        </GameInfoListItem>
-        <GameInfoListItem>Traffic settings</GameInfoListItem>
-        <GameInfoListItem>Pedestrian routes</GameInfoListItem>
-        <GameInfoListItem>Public transport routes</GameInfoListItem>
       </GameInfoSection>
     </GameInfo>
   )

--- a/frontend/src/game/route/RouteGameInfo.tsx
+++ b/frontend/src/game/route/RouteGameInfo.tsx
@@ -18,8 +18,8 @@ export const RouteGameInfo = ({ onClose }: Props) => {
       onClose={onClose}
     >
       <GameInfoParagraph>
-        Navigate from <Bold>A to B</Bold> through the cities' junctions and
-        roads.
+        As a car, navigate from <Bold>A to B</Bold> through the city's junctions
+        and roads.
       </GameInfoParagraph>
       <GameInfoSection
         title='How to play'
@@ -84,9 +84,28 @@ export const RouteGameInfo = ({ onClose }: Props) => {
             correspond with the actual entrance/exit. This might make getting to
             the end point a bit awkward. As Google Maps has additional
             entrance/exit info this also makes the calculated routes a bit
-            different.
+            different. TBD.
+          </GameInfoListItem>
+          <GameInfoListItem>
+            The address auto-complete is set with a south-west and north-east
+            bound. These are not calculated correctly for all cities. This
+            causes some addresses to not be searchable. TBD.
           </GameInfoListItem>
         </GameInfoList>
+      </GameInfoSection>
+      <GameInfoSection
+        title='Features to come'
+        defaultOpen={false}
+      >
+        <GameInfoList>
+          <GameInfoListItem>Versus mode</GameInfoListItem>
+        </GameInfoList>
+        <GameInfoListItem>
+          Play multiple routes in a row, accumulate score / route diff
+        </GameInfoListItem>
+        <GameInfoListItem>Traffic settings</GameInfoListItem>
+        <GameInfoListItem>Pedestrian routes</GameInfoListItem>
+        <GameInfoListItem>Public transport routes</GameInfoListItem>
       </GameInfoSection>
     </GameInfo>
   )

--- a/frontend/src/game/settings/GameSettings.tsx
+++ b/frontend/src/game/settings/GameSettings.tsx
@@ -238,7 +238,7 @@ export const GameSettings = ({
               type='text'
               disabled
               value='Oslo, Norway'
-              title={`In ${draftSettings.mode} mode, city selection is currently only available for Oslo, Norway`}
+              title={`In ${draftSettings.mode} mode, only Oslo, Norway is available`}
               className={s_city_disabled_input}
             />
           </div>

--- a/frontend/src/game/settings/GameSettingsButton.tsx
+++ b/frontend/src/game/settings/GameSettingsButton.tsx
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export const GameSettingsButton = ({ isGameActive, resetGameState }: Props) => {
-  const { isSettingsOpen, setIsSettingsOpen } = useSettingsOpen()
+  const { isSettingsOpen, setIsSettingsOpen, setIsInfoOpen } = useSettingsOpen()
   const gameSettings = useSelector(
     (state: RootState) => state.mapmemo.gameSettings,
   )
@@ -36,6 +36,7 @@ export const GameSettingsButton = ({ isGameActive, resetGameState }: Props) => {
   }
 
   const handleClick = () => {
+    setIsInfoOpen(false)
     setIsSettingsOpen(!isSettingsOpen)
   }
 


### PR DESCRIPTION
## Summary
- Replaces inline `GameInfoButton` panel with a reusable `GameInfo` component system
- `AreaGameInfo` and `RouteGameInfo` provide mode-specific content (route/area selected via Redux game mode)
- `GameInfoSection` renders collapsible subtitle+content blocks (chevron toggle, `defaultOpen` prop)
- Panel layout: sticky header with shadow border, scrollable content, sticky footer (report issue + close)
- Inline text helpers exported: `Bold`, `Italic`, `Underline`

## Test plan
- [x] Open info panel in route mode → RouteGameInfo content shown
- [x] Open info panel in area/name mode → AreaGameInfo content shown
- [x] Collapse/expand sections via chevron
- [x] Sections with `defaultOpen={false}` start collapsed
- [x] Content scrolls when panel overflows; header and footer stay fixed
- [x] "Report an issue" link opens GitHub issues
- [x] Close button and backdrop click dismiss the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)