### PR TITLE
perf(timer): isolate game timer to GameHUD to prevent cascade re-renders

### DIFF
--- a/frontend/src/game/GameHUD.tsx
+++ b/frontend/src/game/GameHUD.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react'
 import { ScoreBar } from './ScoreBar'
 import type { GameState } from './hooks/useGameState'
+import { useGameTimer } from './hooks/useGameTimer'
 import {
   s_overlayGUI_left,
   s_overlayGUI_item,
@@ -9,10 +11,34 @@ import {
 
 type Props = {
   gameState: GameState
+  onComplete?: (formattedTime: string) => void
 }
 
-export const GameHUD = ({ gameState }: Props) => {
-  const { formattedTime } = gameState
+export const GameHUD = ({ gameState, onComplete }: Props) => {
+  const { formattedTime } = useGameTimer({
+    isRunning: gameState.isTimerRunning,
+    resetKey: gameState.timerResetKey,
+  })
+
+  // Fire onComplete with the frozen time when timer transitions true → false.
+  // formattedTimeRef keeps the latest value without making it an effect dep.
+  const formattedTimeRef = useRef(formattedTime)
+  const wasRunningRef = useRef(false)
+  // Sync ref after every render so captureCompletionTime always reads the
+  // latest formattedTime. Declared first so it runs before captureCompletionTime
+  // when both fire in the same commit.
+  useEffect(function syncFormattedTimeRef() {
+    formattedTimeRef.current = formattedTime
+  })
+  useEffect(
+    function captureCompletionTime() {
+      if (wasRunningRef.current && !gameState.isTimerRunning) {
+        onComplete?.(formattedTimeRef.current)
+      }
+      wasRunningRef.current = gameState.isTimerRunning
+    },
+    [gameState.isTimerRunning, onComplete],
+  )
 
   if (gameState.mode === 'route') {
     return (

--- a/frontend/src/game/GameHUD.tsx
+++ b/frontend/src/game/GameHUD.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { ScoreBar } from './ScoreBar'
-import type { GameState } from './hooks/useGameState'
 import { useGameTimer } from './hooks/useGameTimer'
+import type { GameState } from './hooks/useGameState'
 import {
   s_overlayGUI_left,
   s_overlayGUI_item,
@@ -27,9 +27,13 @@ export const GameHUD = ({ gameState, onComplete }: Props) => {
   // Sync ref after every render so captureCompletionTime always reads the
   // latest formattedTime. Declared first so it runs before captureCompletionTime
   // when both fire in the same commit.
-  useEffect(function syncFormattedTimeRef() {
-    formattedTimeRef.current = formattedTime
-  })
+  useEffect(
+    function syncFormattedTimeRef() {
+      formattedTimeRef.current = formattedTime
+    },
+    [formattedTime],
+  )
+
   useEffect(
     function captureCompletionTime() {
       if (wasRunningRef.current && !gameState.isTimerRunning) {

--- a/frontend/src/game/hooks/useGameState.ts
+++ b/frontend/src/game/hooks/useGameState.ts
@@ -1,9 +1,9 @@
+import { useState } from 'react'
 import { useAreaGameState, type AreaGameState } from './useAreaGameState'
 import {
   useRouteGameState,
   type RouteGameState,
 } from '../route/useRouteGameState'
-import { useGameTimer } from './useGameTimer'
 
 export type { AreaGameState } from './useAreaGameState'
 export type { RouteGameState } from '../route/useRouteGameState'
@@ -12,7 +12,8 @@ type AreaActive = {
   mode: 'click' | 'name'
   areaGameState: AreaGameState
   routeGameState: null
-  formattedTime: string
+  isTimerRunning: boolean
+  timerResetKey: number
   resetGame: () => void
 }
 
@@ -20,7 +21,8 @@ type RouteActive = {
   mode: 'route'
   areaGameState: null
   routeGameState: RouteGameState
-  formattedTime: string
+  isTimerRunning: boolean
+  timerResetKey: number
   resetGame: () => void
 }
 
@@ -34,32 +36,30 @@ type Props = {
 /**
  * Orchestrates area and route game state behind a discriminated union on `mode`.
  * Checking `mode` exposes the corresponding `areaGameState` or `routeGameState`.
- * Composes the mode-specific hook with `useGameTimer` and provides a unified
- * `resetGame` that resets both state and timer.
+ * Provides `isTimerRunning` and `timerResetKey` for the timer owned by GameHUD,
+ * and a unified `resetGame` that resets both game state and the timer.
  */
 export const useGameState = ({ features, isMapReady }: Props): GameState => {
   const areaState = useAreaGameState({ features })
   const routeState = useRouteGameState()
+  const [timerResetKey, setTimerResetKey] = useState(0)
 
   const isTimerRunning = routeState
     ? routeState.isReady && isMapReady && !routeState.isComplete
     : !!areaState && features.length > 0 && isMapReady && !areaState.isComplete
 
-  const { formattedTime, resetTimer } = useGameTimer({
-    isRunning: isTimerRunning,
-  })
-
   if (routeState) {
     const routeReset = routeState.reset
     const resetGame = () => {
       routeReset()
-      resetTimer()
+      setTimerResetKey((k) => k + 1)
     }
     return {
       mode: 'route',
       areaGameState: null,
       routeGameState: routeState,
-      formattedTime,
+      isTimerRunning,
+      timerResetKey,
       resetGame,
     }
   }
@@ -69,13 +69,14 @@ export const useGameState = ({ features, isMapReady }: Props): GameState => {
   const areaReset = area.resetGameState
   const resetGame = () => {
     areaReset()
-    resetTimer()
+    setTimerResetKey((k) => k + 1)
   }
   return {
     mode: area.mode,
     areaGameState: area,
     routeGameState: null,
-    formattedTime,
+    isTimerRunning,
+    timerResetKey,
     resetGame,
   }
 }

--- a/frontend/src/game/hooks/useGameTimer.ts
+++ b/frontend/src/game/hooks/useGameTimer.ts
@@ -1,54 +1,56 @@
 import { useEffect, useRef, useState } from 'react'
 
 export type GameTimer = {
-  elapsedMs: number
   formattedTime: string
-  resetTimer: () => void
 }
 
 type Props = {
   isRunning: boolean
+  resetKey?: number
 }
 
 const TICK_INTERVAL_MS = 100
 
 /** Tracks elapsed game time with 100ms tick resolution. Formatted as `m:ss.t`. */
-export const useGameTimer = ({ isRunning }: Props): GameTimer => {
+export const useGameTimer = ({ isRunning, resetKey = 0 }: Props): GameTimer => {
   // useRef needed to track start time across renders without triggering
   // re-renders. Only the interval tick updates displayed state.
   const startTimeRef = useRef<number | null>(null)
-  const [elapsedMs, setElapsedMs] = useState(0)
+  // lastResetKeyRef lets the setInterval callback tag each tick with the
+  // resetKey active when the interval was started, so stale ticks from a
+  // previous game are ignored without calling setState in the effect body.
+  const lastResetKeyRef = useRef(resetKey)
+  const [timerState, setTimerState] = useState({
+    elapsedMs: 0,
+    forResetKey: resetKey,
+  })
 
   useEffect(
     function trackElapsedTime() {
       if (!isRunning) {
+        startTimeRef.current = null
         return
       }
 
-      if (startTimeRef.current === null) {
-        startTimeRef.current = Date.now()
-      }
-
+      startTimeRef.current = Date.now()
+      lastResetKeyRef.current = resetKey
       const interval = setInterval(() => {
-        const elapsed = Date.now() - (startTimeRef.current ?? Date.now())
-        setElapsedMs(elapsed)
+        setTimerState({
+          elapsedMs: Date.now() - (startTimeRef.current ?? Date.now()),
+          forResetKey: lastResetKeyRef.current,
+        })
       }, TICK_INTERVAL_MS)
 
       return () => clearInterval(interval)
     },
-    [isRunning],
+    [isRunning, resetKey],
   )
 
-  const resetTimer = () => {
-    startTimeRef.current = Date.now()
-    setElapsedMs(0)
-  }
-
-  return {
-    elapsedMs,
-    formattedTime: formatTime(elapsedMs),
-    resetTimer,
-  }
+  // When resetKey has advanced (new game, timer not yet started), show 0
+  // instead of the frozen final time from the previous game.
+  const elapsedMs =
+    timerState.forResetKey === resetKey ? timerState.elapsedMs : 0
+  return { formattedTime: formatTime(elapsedMs) }
 }
 
 const formatTime = (totalMs: number): string => {

--- a/frontend/src/game/route/RouteGame.tsx
+++ b/frontend/src/game/route/RouteGame.tsx
@@ -12,6 +12,7 @@ const EMPTY_FEATURES: google.maps.Data.Feature[] = []
 
 export const RouteGame = () => {
   const [isGMapReady, setIsGMapReady] = useState(false)
+  const [finalTime, setFinalTime] = useState('')
   const gameState = useGameState({
     features: EMPTY_FEATURES,
     isMapReady: isGMapReady,
@@ -49,7 +50,10 @@ export const RouteGame = () => {
       >
         {isGMapReady && (
           <>
-            <GameHUD gameState={gameState} />
+            <GameHUD
+              gameState={gameState}
+              onComplete={setFinalTime}
+            />
             <GameUI gameState={gameState} />
             {routeGameState.isComplete &&
               routeGameState.startAddress &&
@@ -58,7 +62,7 @@ export const RouteGame = () => {
                   startAddress={routeGameState.startAddress}
                   endAddress={routeGameState.endAddress}
                   path={routeGameState.path}
-                  formattedTime={gameState.formattedTime}
+                  formattedTime={finalTime}
                   onPlayAgain={gameState.resetGame}
                 />
               )}

--- a/frontend/src/game/route/RouteGame.tsx
+++ b/frontend/src/game/route/RouteGame.tsx
@@ -57,6 +57,7 @@ export const RouteGame = () => {
             <GameUI gameState={gameState} />
             {routeGameState.isComplete &&
               routeGameState.startAddress &&
+              finalTime !== '' &&
               routeGameState.endAddress && (
                 <RouteResults
                   startAddress={routeGameState.startAddress}

--- a/frontend/src/game/route/useRouteGameState.ts
+++ b/frontend/src/game/route/useRouteGameState.ts
@@ -83,7 +83,6 @@ export const useRouteGameState = (): RouteGameState | null => {
       if (mode !== 'route') {
         return
       }
-
       let isActive = true
 
       const init = async () => {

--- a/frontend/src/game/route/useRouteMapRendering.ts
+++ b/frontend/src/game/route/useRouteMapRendering.ts
@@ -170,7 +170,6 @@ export const useRouteMapRendering = ({
       if (!map) {
         return
       }
-
       const nextIds = new Set(availableJunctions.map((i) => i.id))
       const prevIds = new Set(dotMarkersMapRef.current.keys())
 
@@ -236,7 +235,6 @@ export const useRouteMapRendering = ({
       if (!map) {
         return
       }
-
       const availableIds = new Set(availableJunctions.map((j) => j.id))
 
       // Group 1-based visit indices by junction ID


### PR DESCRIPTION
## Summary

- `useGameTimer` was called in `useGameState`, which is called in `AreaGame`/`RouteGame`. Every 100ms tick caused the entire game component tree to re-render, running `createSeededEntries` (shuffle) and other expensive work each time.
- Moved `useGameTimer` into `GameHUD` — now only that leaf component re-renders on each tick.
- `useGameState` now returns `isTimerRunning` + `timerResetKey` instead of `formattedTime`. `resetGame` increments `timerResetKey` to signal a reset.
- `RouteGame` captures the final time via `GameHUD`'s `onComplete` callback and passes it to `RouteResults`.
- `useGameTimer` redesigned to avoid `setState` in effect body (lint rule): timer state now tracks `forResetKey` so the display shows `0` after a reset without an extra state update.

## Test plan

- [ ] Area mode: timer ticks without causing re-renders of `AreaGame` (check DevTools Profiler)
- [ ] Route mode: timer ticks, completes, final time shown in `RouteResults`
- [ ] Reset game: timer resets to `0:00.0`
- [ ] Switch between area and route modes: timer starts/stops correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)