### PR TITLE
UX changes to name mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
       content="#f8fafc"
     />
     <meta
-      name="apple-mobile-web-app-capable"
+      name="mobile-web-app-capable"
       content="yes"
     />
     <meta

--- a/frontend/src/components/AutoCompleteInput.tsx
+++ b/frontend/src/components/AutoCompleteInput.tsx
@@ -10,12 +10,15 @@ export type AutoCompleteInputHandle = {
   focus: () => void
   open: () => void
   select: () => void
+  shake: () => void
   getInputElement: () => HTMLInputElement | null
 }
 
 type Props = {
-  focusHandleRef?: RefObject<AutoCompleteInputHandle | null> // used to open/select/focus input from outside.
+  focusHandleRef?: RefObject<AutoCompleteInputHandle | null> // used to open/select/focus/shake input from outside.
   suggestions: string[]
+  /** Hides suggestions and submits are not forced to be in suggestions.*/
+  noSuggestions?: boolean
   value: string
   onChange: (value: string) => void
   onSelect: (value: string) => void
@@ -23,6 +26,10 @@ type Props = {
   placeholder?: string
   inputClassName?: string
   containerClassName?: string
+  /** When provided, the input is wrapped in a pill div with this class, and `inputClassName` styles the inner input only. */
+  inputWrapperClassName?: string
+  /** Bold prefix text rendered before the editable input (inside the pill wrapper). */
+  prefix?: string
   disabled?: boolean
   autoFocus?: boolean
   openOnFocus?: boolean
@@ -31,6 +38,7 @@ type Props = {
 export const AutoCompleteInput = ({
   focusHandleRef,
   suggestions,
+  noSuggestions = false,
   value,
   onChange,
   onSelect,
@@ -38,6 +46,8 @@ export const AutoCompleteInput = ({
   placeholder,
   inputClassName,
   containerClassName,
+  inputWrapperClassName,
+  prefix,
   disabled,
   autoFocus,
   openOnFocus = false,
@@ -45,16 +55,23 @@ export const AutoCompleteInput = ({
   const [isOpen, setIsOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const [previewValue, setPreviewValue] = useState('')
+  const [isShaking, setIsShaking] = useState(false)
 
   // useRef: DOM handle for focus/select (imperative handle) and click-outside + scroll-into-view.
   const inputElRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const dropdownRef = useRef<HTMLUListElement>(null)
 
+  const triggerShake = () => {
+    setIsShaking(true)
+    setTimeout(() => setIsShaking(false), 400)
+  }
+
   useImperativeHandle(focusHandleRef, () => ({
     focus: () => inputElRef.current?.focus(),
     open: () => setIsOpen(true),
     select: () => inputElRef.current?.select(),
+    shake: triggerShake,
     getInputElement: () => inputElRef.current,
   }))
 
@@ -73,13 +90,21 @@ export const AutoCompleteInput = ({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  // When a prefix is shown as a pill, skip inline preview — the pill already gives context
   const displayValue = highlightedIndex >= 0 ? previewValue : value
-  const shouldShowDropdown = isOpen && suggestions.length > 0
+
+  const shouldShowDropdown = !noSuggestions && isOpen && suggestions.length > 0
 
   const updateHighlight = (newIndex: number) => {
     setHighlightedIndex(newIndex)
     if (newIndex >= 0 && newIndex < suggestions.length) {
-      setPreviewValue(suggestions[newIndex])
+      // When a prefix is revealed, only preview the suffix portion in the input
+      const fullSuggestion = suggestions[newIndex]
+      const preview =
+        prefix && fullSuggestion.toLowerCase().startsWith(prefix.toLowerCase())
+          ? fullSuggestion.slice(prefix.length)
+          : fullSuggestion
+      setPreviewValue(preview)
       const item = dropdownRef.current?.children[newIndex] as
         | HTMLElement
         | undefined
@@ -102,32 +127,42 @@ export const AutoCompleteInput = ({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Tab') {
+    if (e.key === 'Enter') {
       if (shouldShowDropdown) {
         e.preventDefault()
-        confirmSelection(suggestions[0])
+        confirmSelection(
+          suggestions[highlightedIndex >= 0 ? highlightedIndex : 0],
+        )
+      } else if (noSuggestions) {
+        e.preventDefault()
+        confirmSelection(prefix + value)
+      } else {
+        e.preventDefault()
+        triggerShake()
+        inputElRef.current?.select()
       }
-      // No suggestions — let Tab/Shift+Tab bubble for natural focus traversal
       return
+    }
+
+    if (e.ctrlKey && e.key === ' ') {
+      e.preventDefault()
+      setIsOpen(true)
     }
 
     if (!shouldShowDropdown) {
       return
     }
 
-    if (e.key === 'ArrowDown') {
+    if (e.key === 'ArrowDown' || (!e.shiftKey && e.key === 'Tab')) {
       e.preventDefault()
       const next =
         highlightedIndex < suggestions.length - 1 ? highlightedIndex + 1 : 0
       updateHighlight(next)
-    } else if (e.key === 'ArrowUp') {
+    } else if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
       e.preventDefault()
       const next =
         highlightedIndex > 0 ? highlightedIndex - 1 : suggestions.length - 1
       updateHighlight(next)
-    } else if (e.key === 'Enter' && highlightedIndex >= 0) {
-      e.preventDefault()
-      confirmSelection(suggestions[highlightedIndex])
     } else if (e.key === 'Escape') {
       setIsOpen(false)
       setHighlightedIndex(-1)
@@ -148,25 +183,36 @@ export const AutoCompleteInput = ({
     onBlur?.()
   }
 
+  const inputEl = (
+    <input
+      ref={inputElRef}
+      type='text'
+      value={displayValue}
+      onChange={handleInputChange}
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      placeholder={placeholder}
+      autoFocus={autoFocus}
+      autoComplete='off'
+      disabled={disabled}
+      className={inputClassName}
+    />
+  )
+
   return (
     <div
       ref={containerRef}
-      className={containerClassName}
+      className={`${containerClassName ?? ''} ${isShaking ? 'animate-shake' : ''}`}
     >
-      <input
-        ref={inputElRef}
-        type='text'
-        value={displayValue}
-        onChange={handleInputChange}
-        onKeyDown={handleKeyDown}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-        autoComplete='off'
-        disabled={disabled}
-        className={inputClassName}
-      />
+      {inputWrapperClassName != null ? (
+        <div className={inputWrapperClassName}>
+          {prefix && <span className={s_revealed_prefix}>{prefix}</span>}
+          {inputEl}
+        </div>
+      ) : (
+        inputEl
+      )}
       {shouldShowDropdown && (
         <ul
           ref={dropdownRef}
@@ -185,10 +231,17 @@ export const AutoCompleteInput = ({
                 setPreviewValue('')
               }}
               className={sf_dropdown_item(index === highlightedIndex)}
-              title={index === 0 ? 'Press Tab to submit first suggestion' : ''}
+              title={
+                index === 0
+                  ? 'Press Tab or Enter to submit first suggestion'
+                  : ''
+              }
             >
               <span>{label}</span>
-              {index === 0 && <span className={s_tab_hint}>&#x21E5;</span>}
+              {((index === 0 && highlightedIndex === -1) ||
+                index === highlightedIndex) && (
+                <span className={s_tab_hint}>&#x21B5;</span>
+              )}
             </li>
           ))}
         </ul>
@@ -198,7 +251,7 @@ export const AutoCompleteInput = ({
 }
 
 const s_dropdown =
-  'absolute left-0 right-0 z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg'
+  'absolute left-0 right-0 z-10 mt-1 max-h-24 sm:max-h-48 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg'
 const sf_dropdown_item = (isHighlighted: boolean) =>
   `flex cursor-pointer items-center justify-between px-4 py-2 text-left text-sm ${
     isHighlighted
@@ -206,3 +259,4 @@ const sf_dropdown_item = (isHighlighted: boolean) =>
       : 'text-slate-700 hover:bg-slate-50'
   }`
 const s_tab_hint = 'text-base text-slate-400'
+const s_revealed_prefix = 'select-none font-bold text-slate-700 shrink-0'

--- a/frontend/src/components/AutoCompleteInput.tsx
+++ b/frontend/src/components/AutoCompleteInput.tsx
@@ -33,6 +33,7 @@ type Props = {
   disabled?: boolean
   autoFocus?: boolean
   openOnFocus?: boolean
+  legalValueHints?: { legal: string; illegal: string }
 }
 
 export const AutoCompleteInput = ({
@@ -51,6 +52,7 @@ export const AutoCompleteInput = ({
   disabled,
   autoFocus,
   openOnFocus = false,
+  legalValueHints,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
@@ -209,6 +211,25 @@ export const AutoCompleteInput = ({
         <div className={inputWrapperClassName}>
           {prefix && <span className={s_revealed_prefix}>{prefix}</span>}
           {inputEl}
+          {noSuggestions && legalValueHints ? (
+            suggestions
+              .map((suggestion) => suggestion.toLowerCase())
+              .includes((prefix + value).toLowerCase()) ? (
+              <span
+                className={s_legal_value_hint}
+                title={legalValueHints.legal}
+              >
+                &#x2714;
+              </span>
+            ) : (
+              <span
+                className={s_illegal_value_hint}
+                title={legalValueHints.illegal}
+              >
+                &#x274C;
+              </span>
+            )
+          ) : null}
         </div>
       ) : (
         inputEl
@@ -240,7 +261,7 @@ export const AutoCompleteInput = ({
               <span>{label}</span>
               {((index === 0 && highlightedIndex === -1) ||
                 index === highlightedIndex) && (
-                <span className={s_tab_hint}>&#x21B5;</span>
+                <span className={s_submit_hint}>&#x21B5;</span>
               )}
             </li>
           ))}
@@ -258,5 +279,7 @@ const sf_dropdown_item = (isHighlighted: boolean) =>
       ? 'bg-blue-50 text-blue-700'
       : 'text-slate-700 hover:bg-slate-50'
   }`
-const s_tab_hint = 'text-base text-slate-400'
+const s_submit_hint = 'text-base text-slate-400'
+const s_legal_value_hint = 'text-base text-slate-400 cursor-default'
+const s_illegal_value_hint = 'text-base text-slate-400 cursor-default'
 const s_revealed_prefix = 'select-none font-bold text-slate-700 shrink-0'

--- a/frontend/src/components/AutoCompleteInput.tsx
+++ b/frontend/src/components/AutoCompleteInput.tsx
@@ -130,12 +130,13 @@ export const AutoCompleteInput = ({
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
+      // if special behaviour, also include this in handleFormSubmit if within a form.
       if (shouldShowDropdown) {
         e.preventDefault()
         confirmSelection(
           suggestions[highlightedIndex >= 0 ? highlightedIndex : 0],
         )
-      } else if (noSuggestions) {
+      } else if (noSuggestions && (prefix + value).trim().length > 0) {
         e.preventDefault()
         confirmSelection(prefix + value)
       } else {
@@ -211,7 +212,9 @@ export const AutoCompleteInput = ({
         <div className={inputWrapperClassName}>
           {prefix && <span className={s_revealed_prefix}>{prefix}</span>}
           {inputEl}
-          {noSuggestions && legalValueHints ? (
+          {noSuggestions &&
+          legalValueHints &&
+          (prefix + value).trim().length > 0 ? (
             suggestions
               .map((suggestion) => suggestion.toLowerCase())
               .includes((prefix + value).toLowerCase()) ? (
@@ -252,11 +255,7 @@ export const AutoCompleteInput = ({
                 setPreviewValue('')
               }}
               className={sf_dropdown_item(index === highlightedIndex)}
-              title={
-                index === 0
-                  ? 'Press Tab or Enter to submit first suggestion'
-                  : ''
-              }
+              title={index === 0 ? 'Press Enter to submit this suggestion' : ''}
             >
               <span>{label}</span>
               {((index === 0 && highlightedIndex === -1) ||

--- a/frontend/src/game/AreaGame.tsx
+++ b/frontend/src/game/AreaGame.tsx
@@ -7,6 +7,7 @@ import { useFeaturesInPlay } from './hooks/useFeaturesInPlay.ts'
 import { useGameState } from './hooks/useGameState.ts'
 import { useAreaGameStyling } from './hooks/useAreaGameStyling'
 import { useFeatureLabels } from './hooks/useFeatureLabels'
+import { useMapAutoCenter } from './hooks/useMapAutoCenter'
 import { GameUI } from './GameUI.tsx'
 import type { MapContext } from './types.ts'
 import { AREA_MODE_MAP_ID } from './consts.ts'
@@ -39,6 +40,13 @@ export const AreaGame = () => {
     areaGameState: areaGameState,
     mapContext,
     features: featuresInPlay,
+  })
+  useMapAutoCenter({
+    currentEntry: areaGameState.currentEntry,
+    prevGuess: areaGameState.prevGuess,
+    map: mapContext?.map ?? null,
+    features: featuresInPlay,
+    isEnabled: areaGameState.mode === 'name',
   })
 
   const handleMapReady = (payload: MapContext) => {

--- a/frontend/src/game/NameModeInput.tsx
+++ b/frontend/src/game/NameModeInput.tsx
@@ -15,7 +15,13 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
   const { difficulty, registerNameGuess, prevGuess, currentEntry } =
     areaGameState
   const { isSettingsOpen, isInfoOpen } = useSettingsOpen()
-  const [typedValue, setTypedValue] = useState('')
+  const [typedSuffix, setTypedSuffix] = useState('')
+  // Track which entry the suffix belongs to — reset when entry changes (avoids effect)
+  const [suffixEntryId, setSuffixEntryId] = useState(currentEntry?.id)
+  if (suffixEntryId !== currentEntry?.id) {
+    setSuffixEntryId(currentEntry?.id)
+    setTypedSuffix('')
+  }
 
   const inputRef = useRef<AutoCompleteInputHandle>(null)
   useKeepKeyboardOnMapTouch(
@@ -24,32 +30,33 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
     !isSettingsOpen && !isInfoOpen,
   )
 
+  // Number of revealed letters = consecutive incorrect guesses for this area
+  const revealedCount = prevGuess.isCorrect
+    ? 0
+    : prevGuess.consecutiveIncorrectGuesses
+  const revealedPrefix = currentEntry?.label.slice(0, revealedCount) ?? ''
+  const fullValue = revealedPrefix + typedSuffix
+
   const filteredSuggestions = useInputSuggestions({
     areaGameState,
-    inputValue: typedValue,
+    inputValue: fullValue,
+    useStartsWith: revealedCount > 0,
   })
 
   const handleSelect = (label: string) => {
     registerNameGuess(label)
-    const isCorrect =
-      label.trim().toLowerCase() === currentEntry?.label.trim().toLowerCase()
-    if (isCorrect) {
-      setTypedValue('')
-    } else {
-      setTypedValue(label)
-    }
+    setTypedSuffix('')
     inputRef.current?.focus()
-    if (!isCorrect) {
-      requestAnimationFrame(() => inputRef.current?.select())
-    }
   }
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!typedValue.trim()) {
-      return
+    if (filteredSuggestions.length > 0) {
+      handleSelect(filteredSuggestions[0])
+    } else {
+      inputRef.current?.shake()
+      inputRef.current?.select()
     }
-    handleSelect(typedValue)
   }
 
   // Captures keypresses anywhere on the page and redirects to this input,
@@ -72,7 +79,7 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
           e.preventDefault()
           inputRef.current?.focus()
           inputRef.current?.open()
-          setTypedValue((prev: string) => prev + e.key)
+          setTypedSuffix((prev: string) => prev + e.key)
         }
       }
       document.addEventListener('keydown', handleDocumentKeyDown)
@@ -90,14 +97,19 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
       <AutoCompleteInput
         focusHandleRef={inputRef}
         suggestions={filteredSuggestions}
-        value={typedValue}
-        onChange={setTypedValue}
+        noSuggestions={difficulty === 'hard'}
+        value={typedSuffix}
+        onChange={setTypedSuffix}
         onSelect={handleSelect}
-        placeholder='Type area name...'
+        prefix={revealedPrefix}
+        placeholder={
+          revealedPrefix.length > 0 ? undefined : 'Type area name...'
+        }
         autoFocus
-        openOnFocus={difficulty === 'beginner'}
+        openOnFocus={difficulty === 'beginner' || fullValue.length > 0}
         containerClassName={s_autocomplete_container}
-        inputClassName={sf_name_input(prevGuess.isCorrect)}
+        inputWrapperClassName={sf_name_pill(prevGuess.isCorrect)}
+        inputClassName={sf_name_input(revealedPrefix.length > 0)}
       />
     </form>
   )
@@ -105,9 +117,11 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
 
 const s_name_form = 'pointer-events-auto'
 const s_autocomplete_container = `relative w-74 max-w-xs ${s_overlayGUI_item}`
-const sf_name_input = (isCorrectState: boolean) =>
-  `h-full w-full rounded-full border-2 bg-white px-4 text-left text-lg font-semibold shadow-md outline-none ${
-    isCorrectState
-      ? 'border-slate-300 focus:border-blue-500'
-      : 'border-red-400 focus:border-red-500'
+const sf_name_pill = (isCorrect: boolean) =>
+  `flex h-full items-center rounded-full border-2 bg-white px-4 shadow-md ${
+    isCorrect
+      ? 'border-slate-300 focus-within:border-blue-500'
+      : 'border-red-400 focus-within:border-red-500'
   }`
+const sf_name_input = (hasPrefix: boolean) =>
+  `min-w-0 flex-1 bg-transparent text-left text-lg font-semibold outline-none${hasPrefix ? ' lowercase' : ''}`

--- a/frontend/src/game/NameModeInput.tsx
+++ b/frontend/src/game/NameModeInput.tsx
@@ -110,6 +110,10 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
         containerClassName={s_autocomplete_container}
         inputWrapperClassName={sf_name_pill(prevGuess.isCorrect)}
         inputClassName={sf_name_input(revealedPrefix.length > 0)}
+        legalValueHints={{
+          legal: 'Input matches an area',
+          illegal: 'Input does not match any areas',
+        }}
       />
     </form>
   )

--- a/frontend/src/game/NameModeInput.tsx
+++ b/frontend/src/game/NameModeInput.tsx
@@ -51,6 +51,9 @@ export const NameModeInput = ({ areaGameState }: NameModeInputProps) => {
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    if (difficulty === 'hard') {
+      handleSelect(fullValue)
+    }
     if (filteredSuggestions.length > 0) {
       handleSelect(filteredSuggestions[0])
     } else {

--- a/frontend/src/game/hooks/useGameTimer.ts
+++ b/frontend/src/game/hooks/useGameTimer.ts
@@ -9,7 +9,7 @@ type Props = {
   resetKey?: number
 }
 
-const TICK_INTERVAL_MS = 100
+const TICK_INTERVAL_MS = 1000
 
 /** Tracks elapsed game time with 100ms tick resolution. Formatted as `m:ss.t`. */
 export const useGameTimer = ({ isRunning, resetKey = 0 }: Props): GameTimer => {
@@ -57,6 +57,5 @@ const formatTime = (totalMs: number): string => {
   const totalSeconds = Math.floor(totalMs / 1000)
   const mins = Math.floor(totalSeconds / 60)
   const secs = totalSeconds % 60
-  const tenths = Math.floor((totalMs % 1000) / 100)
-  return `${mins}:${secs.toString().padStart(2, '0')}.${tenths}`
+  return `${mins}:${secs.toString().padStart(2, '0')}`
 }

--- a/frontend/src/game/hooks/useInputSuggestions.ts
+++ b/frontend/src/game/hooks/useInputSuggestions.ts
@@ -5,6 +5,8 @@ import type { AreaGameState } from './useAreaGameState'
 type UseInputSuggestionsProps = {
   areaGameState: AreaGameState
   inputValue: string
+  /**Default is includes */
+  useStartsWith?: boolean
 }
 
 /**
@@ -13,6 +15,7 @@ type UseInputSuggestionsProps = {
 export const useInputSuggestions = ({
   areaGameState,
   inputValue,
+  useStartsWith = false,
 }: UseInputSuggestionsProps) => {
   const { difficulty, areaLabels, completedAreaLabels } = areaGameState
   const allSubAreaNames = useSelector(
@@ -37,7 +40,9 @@ export const useInputSuggestions = ({
       ? suggestionPool
       : inputValue.length > 0
         ? suggestionPool.filter((label) =>
-            label.toLowerCase().includes(inputValue.toLowerCase()),
+            useStartsWith
+              ? label.toLowerCase().startsWith(inputValue.toLowerCase())
+              : label.toLowerCase().includes(inputValue.toLowerCase()),
           )
         : []
 

--- a/frontend/src/game/hooks/useInputSuggestions.ts
+++ b/frontend/src/game/hooks/useInputSuggestions.ts
@@ -22,8 +22,6 @@ export const useInputSuggestions = ({
     (state: RootState) => state.mapmemo.allSubAreaNames,
   )
 
-  const hasAutocomplete = difficulty !== 'hard'
-
   const sorted = [...areaLabels].sort((a, b) =>
     a.localeCompare(b, undefined, { sensitivity: 'base' }),
   )
@@ -34,9 +32,8 @@ export const useInputSuggestions = ({
         : sorted
       : allSubAreaNames
 
-  const filteredSuggestions = !hasAutocomplete
-    ? []
-    : difficulty === 'beginner' && inputValue.length === 0
+  const filteredSuggestions =
+    difficulty === 'beginner' && inputValue.length === 0
       ? suggestionPool
       : inputValue.length > 0
         ? suggestionPool.filter((label) =>

--- a/frontend/src/game/hooks/useKeepKeyboardOnMapTouch.ts
+++ b/frontend/src/game/hooks/useKeepKeyboardOnMapTouch.ts
@@ -43,10 +43,14 @@ export const useKeepKeyboardOnMapTouch = (
       mapTouchActiveRef.current = true
     }
     const handleTouchEnd = (e: TouchEvent) => {
-      if (e.touches.length === 0) {
-        mapTouchActiveRef.current = false
-      }
       activeTouchCountRef.current = e.touches.length
+      if (e.touches.length === 0) {
+        // On mobile, blur fires after touchend. Defer the reset so the blur
+        // handler can still see mapTouchActiveRef.current = true and refocus.
+        setTimeout(() => {
+          mapTouchActiveRef.current = false
+        }, 0)
+      }
     }
     window.addEventListener('touchstart', handleTouchStart, {
       capture: true,

--- a/frontend/src/game/hooks/useMapAutoCenter.ts
+++ b/frontend/src/game/hooks/useMapAutoCenter.ts
@@ -22,7 +22,7 @@ export const useMapAutoCenter = ({
   map,
   features,
   isEnabled,
-}: Props) => {
+}: Props): void => {
   const prevEntryIdRef = useRef<string | null>(null)
   const playAreaBoundsRef = useRef<google.maps.LatLngBounds | null>(null)
 

--- a/frontend/src/game/hooks/useMapAutoCenter.ts
+++ b/frontend/src/game/hooks/useMapAutoCenter.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from 'react'
+import type { GameEntry } from '../types'
+import type { PrevGuess } from './useAreaGameState'
+import { getGeometryCenter } from '../../utils/calculations'
+
+type Props = {
+  currentEntry: GameEntry | null
+  prevGuess: PrevGuess
+  map: google.maps.Map | null
+  features: google.maps.Data.Feature[]
+  isEnabled: boolean
+}
+
+/**
+ * Pans the map to center the next area after a correct guess in name mode.
+ * Clamps the pan so the viewport edge in the direction of movement does not
+ * exceed the play area (bounding box of all features).
+ */
+export const useMapAutoCenter = ({
+  currentEntry,
+  prevGuess,
+  map,
+  features,
+  isEnabled,
+}: Props) => {
+  const prevEntryIdRef = useRef<string | null>(null)
+  const playAreaBoundsRef = useRef<google.maps.LatLngBounds | null>(null)
+
+  useEffect(
+    function computePlayAreaBounds() {
+      if (!map || features.length === 0) {
+        return
+      }
+      const bounds = new google.maps.LatLngBounds()
+      features.forEach((feature) => {
+        feature.getGeometry()?.forEachLatLng((latLng) => bounds.extend(latLng))
+      })
+      playAreaBoundsRef.current = bounds
+    },
+    [map, features],
+  )
+
+  useEffect(
+    function autoCenterOnCorrectGuess() {
+      if (
+        !isEnabled ||
+        !map ||
+        !currentEntry ||
+        !prevGuess.isCorrect ||
+        prevGuess.id === ''
+      ) {
+        return
+      }
+      if (prevEntryIdRef.current === currentEntry.id) {
+        return
+      }
+      prevEntryIdRef.current = currentEntry.id
+
+      const geometry = currentEntry.feature.getGeometry()
+      if (!geometry) {
+        return
+      }
+
+      const centroid = getGeometryCenter(geometry)
+      const playBounds = playAreaBoundsRef.current
+
+      // Reads the CSS var set by useKeyboardHeight (called in GameUI) — no extra listener needed
+      const keyboardHeight = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--keyboard-height',
+        ) || '0',
+      )
+
+      const panTo = (target: google.maps.LatLngLiteral) => {
+        map.panTo(target)
+        // Offset so the target appears at the visible center above the keyboard.
+        // panBy(0, d) with positive d moves the viewport south by d px, placing
+        // the target d px north of center — i.e., at the visible center.
+        if (keyboardHeight > 0) {
+          map.panBy(0, keyboardHeight / 2)
+        }
+      }
+
+      if (!playBounds) {
+        panTo(centroid)
+        return
+      }
+
+      const mapBounds = map.getBounds()
+      const mapCenter = map.getCenter()
+      if (!mapBounds || !mapCenter) {
+        panTo(centroid)
+        return
+      }
+
+      const halfLat = mapCenter.lat() - mapBounds.getSouthWest().lat()
+      const halfLng = mapBounds.getNorthEast().lng() - mapCenter.lng()
+
+      const south = playBounds.getSouthWest().lat()
+      const north = playBounds.getNorthEast().lat()
+      const west = playBounds.getSouthWest().lng()
+      const east = playBounds.getNorthEast().lng()
+
+      // If viewport is larger than play area in a dimension, center on play area mid
+      const clampedLat =
+        south + halfLat > north - halfLat
+          ? (south + north) / 2
+          : Math.max(south + halfLat, Math.min(north - halfLat, centroid.lat))
+
+      const clampedLng =
+        west + halfLng > east - halfLng
+          ? (west + east) / 2
+          : Math.max(west + halfLng, Math.min(east - halfLng, centroid.lng))
+
+      panTo({ lat: clampedLat, lng: clampedLng })
+    },
+    [isEnabled, map, currentEntry, prevGuess.isCorrect, prevGuess.id],
+  )
+}

--- a/frontend/src/game/settings/CityInput.tsx
+++ b/frontend/src/game/settings/CityInput.tsx
@@ -58,6 +58,7 @@ export const CityInput = ({ selectedCity, onSelect }: Props) => {
         placeholder='Search city...'
         containerClassName={sf_autocomplete_container(shake)}
         inputClassName={s_input}
+        openOnFocus
       />
     </div>
   )

--- a/frontend/src/game/settings/RouteAddressInput.tsx
+++ b/frontend/src/game/settings/RouteAddressInput.tsx
@@ -101,6 +101,7 @@ export const RouteAddressInput = ({
             containerClassName={sf_autocomplete_container(shake)}
             inputClassName={s_autocomplete_input}
             disabled={isValidatingRoadName}
+            openOnFocus
           />
         </div>
       )}


### PR DESCRIPTION
- increase timer interval, no deci-seconds. Applies to all modes
- reveal one letter per wrong answer
- reduce auto-complete dropdown height for mobile
- reposition map to center next area on correct answer. Clamped to
  take game area and keyboard into account.
- use startswith instead of includes if any revealed letters
- indicate if input is potential match for hard difficulty

## Test cases

- [x] Timer displays whole seconds only (no deci-seconds)
- [x] Wrong answer reveals one letter of the correct answer
- [x] Auto-complete dropdown is visibly shorter on mobile
- [x] Map recenters on correct answer 
- [x] With revealed letters, auto-complete filters by prefix (startswith), not substring
- [x] Hard difficulty: input matching a valid answer prefix shows a visual indicator
- [x] Hard difficulty: empty input submit doesn't register incorrect guess, input shakes
- [x] **Mobile**: touching the map while keyboard is open does not dismiss the keyboard
- [x] **Mobile**: Hard difficulty: Submitting half-written answer that would have correct guess as suggestion is registered as wrong guess. Tests correct logic in handleFormSubmit 