### PR TITLE
refactor(roads): restructure /api/roads response to separate roads and junctions

### DIFF
--- a/backend/MapMemo.Api.Tests/RoadsEndpointTests.cs
+++ b/backend/MapMemo.Api.Tests/RoadsEndpointTests.cs
@@ -61,9 +61,13 @@ public sealed class RoadsEndpointTests(IntegrationTestFactory factory) : Integra
 
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"roads\"", content);
+        Assert.Contains("\"junctions\"", content);
         Assert.Contains("Karl Johans gate", content);
         Assert.Contains("Akersgata", content);
         Assert.Contains("traffic_signals", content);
+        Assert.Contains("junctionId", content);
+        Assert.Contains("roadJunctionIndex", content);
     }
 
     [Fact]

--- a/backend/MapMemo.Api/Endpoints/GeoDataEndpoints.cs
+++ b/backend/MapMemo.Api/Endpoints/GeoDataEndpoints.cs
@@ -180,32 +180,40 @@ internal static class GeoDataEndpoints {
                     .GroupBy(rj => rj.RoadId)
                     .ToDictionary(g => g.Key, g => g.ToList());
 
-                Dictionary<string, RoadResponseDto> response = new();
+                // Group road_junctions by junction to build connected road names per junction
+                var roadJunctionsByJunction = allRoadJunctions
+                    .GroupBy(rj => rj.JunctionId)
+                    .ToDictionary(g => g.Key, g => g.ToList());
+
+                Dictionary<string, RoadDto> roads = new();
                 foreach ((var roadId, Road r) in roadsById) {
                     List<RoadJunction> roadJunctions = roadJunctionsByRoad.GetValueOrDefault(roadId) ?? [];
 
-                    var junctions = roadJunctions
+                    var junctionRefs = roadJunctions
                         .OrderBy(rj => rj.NodeIndex)
-                        .Select(rj => {
-                            var otherRoads = allRoadJunctions
-                                .Where(x => x.JunctionId == rj.JunctionId && x.RoadId != rj.RoadId)
-                                .Select(x => x.Road.Name)
-                                .ToList();
-                            return new JunctionDto(
-                                rj.JunctionId,
-                                (double)rj.Junction.Lat,
-                                (double)rj.Junction.Lng,
-                                rj.Junction.WayType,
-                                rj.NodeIndex,
-                                otherRoads,
-                                rj.Junction.RoundaboutId);
-                        })
+                        .Select(rj => new RoadJunctionDto(rj.JunctionId, rj.NodeIndex))
                         .ToList();
 
-                    response[r.Name] = new RoadResponseDto(r.Id, r.Name, r.CityId, junctions);
+                    roads[r.Name] = new RoadDto(r.Id, r.Name, r.CityId, junctionRefs);
                 }
 
-                return Results.Json(response);
+                Dictionary<string, JunctionDto> junctions = new();
+                foreach ((var junctionId, List<RoadJunction>? rjs) in roadJunctionsByJunction) {
+                    Junction junctionEntity = rjs[0].Junction;
+                    var connectedRoadNames = rjs
+                        .Select(rj => rj.Road.Name)
+                        .Distinct()
+                        .ToList();
+                    junctions[junctionId.ToString()] = new JunctionDto(
+                        junctionId,
+                        (double)junctionEntity.Lat,
+                        (double)junctionEntity.Lng,
+                        junctionEntity.WayType,
+                        connectedRoadNames,
+                        junctionEntity.RoundaboutId);
+                }
+
+                return Results.Json(new { roads, junctions });
             });
 
         app.MapGet("/api/roads/check", async (

--- a/backend/MapMemo.Api/Models/Roads.cs
+++ b/backend/MapMemo.Api/Models/Roads.cs
@@ -1,8 +1,10 @@
 namespace MapMemo.Api.Models;
 
-internal sealed record JunctionDto(long Id, double Lat, double Lng, string? WayType, int NodeIndex, List<string> ConnectedRoadNames, long? RoundaboutId);
+internal sealed record RoadJunctionDto(long JunctionId, int RoadJunctionIndex);
 
-internal sealed record RoadResponseDto(long Id, string Name, long CityId, List<JunctionDto> Junctions);
+internal sealed record RoadDto(long Id, string Name, long CityId, List<RoadJunctionDto> Junctions);
+
+internal sealed record JunctionDto(long Id, double Lat, double Lng, string? WayType, List<string> ConnectedRoadNames, long? RoundaboutId);
 
 internal sealed record RoadSuggestionDto(string Name, double Score);
 

--- a/frontend/src/api/roadData.ts
+++ b/frontend/src/api/roadData.ts
@@ -1,11 +1,15 @@
 import { fetchWithSessionRetry } from './utils'
 
-export type RoadJunction = {
+export type RoadJunctionRef = {
+  junctionId: number
+  roadJunctionIndex: number
+}
+
+export type Junction = {
   id: number
   lat: number
   lng: number
   wayType: string | null
-  nodeIndex: number
   connectedRoadNames: string[]
   roundaboutId: number | null
 }
@@ -14,10 +18,13 @@ export type RoadInfo = {
   id: number
   name: string
   cityId: number
-  junctions: RoadJunction[]
+  junctions: RoadJunctionRef[]
 }
 
-export type RoadWithJunctionsResponse = Record<string, RoadInfo>
+export type RoadsResponse = {
+  roads: Record<string, RoadInfo>
+  junctions: Record<string, Junction>
+}
 
 export type RoadSuggestion = {
   name: string
@@ -35,7 +42,7 @@ const ROADS_URL = '/api/roads'
 export const fetchRoadWithJunctions = async (
   cityId: number,
   roadName: string,
-): Promise<RoadWithJunctionsResponse> => {
+): Promise<RoadsResponse> => {
   const url = `${ROADS_URL}?city_id=${cityId}&road_name=${encodeURIComponent(roadName)}`
   const response = await fetchWithSessionRetry(url, {
     credentials: 'include',
@@ -44,7 +51,7 @@ export const fetchRoadWithJunctions = async (
   if (!response.ok) {
     throw new Error('Failed to fetch road with junctions')
   }
-  return (await response.json()) as RoadWithJunctionsResponse
+  return (await response.json()) as RoadsResponse
 }
 
 export const checkRoad = async (

--- a/frontend/src/game/route/useRoadGraph.ts
+++ b/frontend/src/game/route/useRoadGraph.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
 import {
   fetchRoadWithJunctions,
+  type Junction,
   type RoadInfo,
-  type RoadJunction,
 } from '../../api/roadData'
 import type { SelectedJunction } from './types'
 
@@ -19,11 +19,13 @@ const normalizeRoadName = (name: string) => name.toLowerCase()
 
 export const useRoadGraph = (cityId: number): RoadGraph => {
   const normalizedRoadCacheRef = useRef<Map<string, RoadInfo>>(new Map())
+  const junctionCacheRef = useRef<Map<string, Junction>>(new Map())
   const normalizedFetchedAsPrimaryRef = useRef<Set<string>>(new Set())
 
   useEffect(
     function resetCacheOnCityChange() {
       normalizedRoadCacheRef.current = new Map()
+      junctionCacheRef.current = new Map()
       normalizedFetchedAsPrimaryRef.current = new Set()
     },
     [cityId],
@@ -39,28 +41,20 @@ export const useRoadGraph = (cityId: number): RoadGraph => {
     }
 
     const response = await fetchRoadWithJunctions(cityId, roadName)
-    // Response is a Record<string, RoadInfo> — primary road + branch roads
-    for (const [name, info] of Object.entries(response)) {
+    for (const [name, info] of Object.entries(response.roads)) {
       const cacheKey = normalizeRoadName(name)
       if (!normalizedRoadCacheRef.current.has(cacheKey)) {
         normalizedRoadCacheRef.current.set(cacheKey, info)
       }
     }
+    for (const [id, junction] of Object.entries(response.junctions)) {
+      if (!junctionCacheRef.current.has(id)) {
+        junctionCacheRef.current.set(id, junction)
+      }
+    }
     normalizedFetchedAsPrimaryRef.current.add(key)
     return normalizedRoadCacheRef.current.get(key) ?? null
   }
-
-  const toSelectedJunction = (
-    junction: RoadJunction,
-    roadName: string,
-  ): SelectedJunction => ({
-    id: junction.id,
-    lat: junction.lat,
-    lng: junction.lng,
-    nodeIndex: junction.nodeIndex,
-    roadName,
-    connectedRoadNames: junction.connectedRoadNames,
-  })
 
   const getJunctionsForRoad = (roadName: string): SelectedJunction[] => {
     const road = normalizedRoadCacheRef.current.get(normalizeRoadName(roadName))
@@ -68,7 +62,22 @@ export const useRoadGraph = (cityId: number): RoadGraph => {
       return []
     }
     // Use road.name (OSM canonical) so junction roadName is properly capitalised
-    return road.junctions.map((jx) => toSelectedJunction(jx, road.name))
+    return road.junctions.flatMap((ref) => {
+      const junction = junctionCacheRef.current.get(ref.junctionId.toString())
+      if (!junction) {
+        return []
+      }
+      return [
+        {
+          id: junction.id,
+          lat: junction.lat,
+          lng: junction.lng,
+          nodeIndex: ref.roadJunctionIndex,
+          roadName: road.name,
+          connectedRoadNames: junction.connectedRoadNames,
+        } satisfies SelectedJunction,
+      ]
+    })
   }
 
   const isFetchedAsPrimary = (roadName: string): boolean =>
@@ -79,6 +88,7 @@ export const useRoadGraph = (cityId: number): RoadGraph => {
 
   const reset = () => {
     normalizedRoadCacheRef.current = new Map()
+    junctionCacheRef.current = new Map()
     normalizedFetchedAsPrimaryRef.current = new Set()
   }
 


### PR DESCRIPTION
## Summary
- \`/api/roads\` now returns \`{ roads: Record<string, RoadDto>, junctions: Record<string, JunctionDto> }\` instead of a flat \`Record<string, RoadResponseDto>\`
- \`RoadDto.junctions\` is a list of \`RoadJunctionDto\` (junctionId + roadJunctionIndex) — no longer embeds full junction data
- \`JunctionDto\` drops \`nodeIndex\` (road-specific) and exposes \`connectedRoadNames\` for all roads at that junction
- Frontend updated: \`RoadJunctionRef\` + \`Junction\` types replace old \`RoadJunction\`; \`useRoadGraph\` now maintains a separate junction cache and joins refs at access time

## Test plan
- [ ] Backend: 32/32 tests pass (\`RoadsEndpointTests\` updated to assert new shape)
- [ ] Frontend: \`pnpm run-checks\` passes (lint, types, tests, build)
- [ ] Manual: load route game, verify junctions render and path navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)